### PR TITLE
Allow moving base directory for instance in resource provider

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -50,8 +50,6 @@ attribute :user, :kind_of => String, :required => true
 attribute :shutdown_wait, :kind_of => String, :default => "5"
 attribute :manage_config_file, :equal_to => [true, false], :default => false
 attribute :base, :kind_of => String, :default => ""
-  
-end
 
 
 # we have to set default for the supports attribute

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -48,7 +48,7 @@ attribute :more_opts, :kind_of => Array, :default => []
 attribute :env, :kind_of => Array, :default => []
 attribute :user, :kind_of => String, :required => true
 attribute :shutdown_wait, :kind_of => String, :default => "5"
-attribute :manage_config_file, :equal_to => [true, false], :default => def false
+attribute :manage_config_file, :equal_to => [true, false], :default => false
 attribute :base, :kind_of => String, :default => ""
   
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -48,7 +48,11 @@ attribute :more_opts, :kind_of => Array, :default => []
 attribute :env, :kind_of => Array, :default => []
 attribute :user, :kind_of => String, :required => true
 attribute :shutdown_wait, :kind_of => String, :default => "5"
-attribute :manage_config_file, :equal_to => [true, false], :default => false
+attribute :manage_config_file, :equal_to => [true, false], :default => def false
+attribute :base, :kind_of => String, :default => ""
+  
+end
+
 
 # we have to set default for the supports attribute
 # in initializer since it is a 'reserved' attribute name
@@ -56,7 +60,9 @@ def initialize(*args)
   require 'pathname'
   super
   @action = :install
-  catalina_parent = Pathname.new(node['tomcat']['home']).parent.to_s
-  @base = "#{catalina_parent}/#{@name}"
+  if @base == "" then
+    catalina_parent = Pathname.new(node['tomcat']['home']).parent.to_s
+    @base = "#{catalina_parent}/#{@name}"
+  end
   @supports = {:report => true, :exception => true}
 end


### PR DESCRIPTION
Adds a writable attribute for the base directory of the new instance to the resource provider.  If not specified, use the old logic of placing it alongside the tomcat software install.
