### PR TITLE
Fix the default configuration template to work properly with the LWRP.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name		"tomcat"
 maintainer       "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Installs/Configures tomcat"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.12.10"
+version          "0.12.11"
 
 %w{ java logrotate ark }.each do |cb|
   depends cb

--- a/templates/default/default_tomcat.erb
+++ b/templates/default/default_tomcat.erb
@@ -6,32 +6,29 @@
 
 SHUTDOWN_WAIT=<%= @tomcat.shutdown_wait %>
 TOMCAT_USER=<%= @tomcat.user %>
-TOMCAT_GROUP=<%= @tomcat.group %>
+TOMCAT_GROUP=<%= @tomcat.user %>
 JAVA_HOME=<%= node["java"]["java_home"] %>
 CATALINA_HOME=<%= node["tomcat"]["home"] %>
 CATALINA_BASE=<%= @tomcat.base %>
 CATALINA_PID="/var/run/<%= @tomcat.params['pid_file'] %>"
 
-JAVA_OPTS="<%= @tomcat.jvm_opts.join(' ') + " "
- @tomcat.jmx_opts.join(' ') +  " " +
- @tomcat.webapp_opts.join(' ') + " " +
- @tomcat.more_opts.join(' ') %>"
+JAVA_OPTS="<%= @tomcat.jvm_opts.join(' ') %> <%= @tomcat.jmx_opts.join(' ') %> <%= @tomcat.webapp_opts.join(' ') %> <%= @tomcat.more_opts.join(' ') %>"
 
-<% unless @tomcat.jmx_password -%>
+<%- unless @tomcat.jmx_password -%>
 JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.access.file=#{@tomcat.jmx_access_file} " %> "
 JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.password.file=#{@tomcat.jmx_password_file} " %> "
-<% end -%>
+<%- end -%>
 
-<% if  @tomcat.env -%>
-<% @tomcat.env.each do |envvar| -%>
+<%- if  @tomcat.env -%>
+<%- @tomcat.env.each do |envvar| -%>
 export <%= envvar %>
-<% end -%>
-<% end -%>
+<%- end -%>
+<%- end -%>
 
 JAVA_ENDORSED_DIRS="$CATALINA_HOME/endorsed"
 
 # Use the Java security manager? (yes/no, default: no)
 TOMCAT6_SECURITY=<%= @tomcat.use_security_manager ? "yes" : "no" %>
 
-CATALINA_TMPDIR=<%= @tomcat.tmp_dir %>
+CATALINA_TMPDIR=<%= @tomcat.params['tmp_dir'] %>
 

--- a/templates/default/default_tomcat.erb
+++ b/templates/default/default_tomcat.erb
@@ -4,27 +4,26 @@
 # Local modifications will be overwritten by Chef.
 #
 
-SHUTDOWN_WAIT=<%= @tomcat["shutdown_wait"] %>
-TOMCAT_USER=<%= @tomcat["user"] %>
-TOMCAT_GROUP=<%= @tomcat["group"] %>
+SHUTDOWN_WAIT=<%= @tomcat.shutdown_wait %>
+TOMCAT_USER=<%= @tomcat.user %>
+TOMCAT_GROUP=<%= @tomcat.group %>
 JAVA_HOME=<%= node["java"]["java_home"] %>
-CATALINA_HOME=<%= @tomcat["home"] %>
-CATALINA_BASE=<%= @tomcat["base"] %>
-CATALINA_PID="/var/run/<%= @tomcat["pid_file"] %>"
+CATALINA_HOME=<%= node["tomcat"]["home"] %>
+CATALINA_BASE=<%= @tomcat.base %>
+CATALINA_PID="/var/run/<%= @tomcat.params['pid_file'] %>"
 
-JAVA_OPTS="<%= @tomcat['jvm_opts'].join(' ') + 
- @tomcat['jmx_opts'].join(' ') +  " " +
- @tomcat['webapp_opts'].join(' ') + " " +
- @tomcat['more_opts'].join(' ') %>"
+JAVA_OPTS="<%= @tomcat.jvm_opts.join(' ') + " "
+ @tomcat.jmx_opts.join(' ') +  " " +
+ @tomcat.webapp_opts.join(' ') + " " +
+ @tomcat.more_opts.join(' ') %>"
 
-<% unless @tomcat.has_key?("jmx_password") -%>
-JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.access.file=#{@tomcat["jmx_access_file"]} " %> "
-JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.password.file=#{@tomcat["jmx_password_file"]} " %> "
+<% unless @tomcat.jmx_password -%>
+JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.access.file=#{@tomcat.jmx_access_file} " %> "
+JMX_OPTS=$JMX_OPTS" <%= "-Dcom.sun.management.jmxremote.password.file=#{@tomcat.jmx_password_file} " %> "
 <% end -%>
 
-
-<% if  @tomcat['env'] -%>
-<% @tomcat['env'].each do |envvar| -%>
+<% if  @tomcat.env -%>
+<% @tomcat.env.each do |envvar| -%>
 export <%= envvar %>
 <% end -%>
 <% end -%>
@@ -32,7 +31,7 @@ export <%= envvar %>
 JAVA_ENDORSED_DIRS="$CATALINA_HOME/endorsed"
 
 # Use the Java security manager? (yes/no, default: no)
-TOMCAT6_SECURITY=<%= @tomcat["use_security_manager"] ? "yes" : "no" %>
+TOMCAT6_SECURITY=<%= @tomcat.use_security_manager ? "yes" : "no" %>
 
-CATALINA_TMPDIR=<%= @tomcat["tmp_dir"] %>
+CATALINA_TMPDIR=<%= @tomcat.tmp_dir %>
 


### PR DESCRIPTION
The `default_tomcat.erb` default configuration file does not work with LWRPs because it uses hash values instead of dot notation and the `Chef::Resource` object does not support the `[]` operator.
